### PR TITLE
Fix missing vendor.min.js and script.min.js

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -29,8 +29,7 @@
             </ul>
         </div>
     </div>
-    <script src="./js/build/vendor.min.js"></script>
-    <script src="./js/build/script.min.js"></script>
+    <script src="./js/vendor/knockout-3.3.0.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Fix missing `js/build/vendor.min.js` and `js/build/script.min.js`, instead use new `js/vendor/knockout-3.3.0.js`